### PR TITLE
[RM4-32218] Add missing public properties

### DIFF
--- a/src/Diagnostics/LoggerBase.php
+++ b/src/Diagnostics/LoggerBase.php
@@ -16,6 +16,10 @@ class LoggerBase
      * @param string $messageToWrite The message to write.
      *
      */
+
+	public $ServiceRequestLoggingLocation;
+	public $EnableRequestResponseLogging;
+
     public function Log($idsTraceLevel, $messageToWrite)
     {
         $fileToWrite = CoreConstants::DEFAULT_LOGGINGLOCATION . '/executionlog.txt';

--- a/src/XSD2PHP/src/com/mikebevz/xsd2php/Php2Xml.php
+++ b/src/XSD2PHP/src/com/mikebevz/xsd2php/Php2Xml.php
@@ -46,6 +46,7 @@ class Php2Xml extends Common
 
 
     protected $rootTagName;
+	protected $rootNsName;
 
     private $logger;
 


### PR DESCRIPTION
Add properties, that are used in LocalConfigReader::setupLogger()